### PR TITLE
Add `skip` function to `Arr`, `Map` and `Collection`.

### DIFF
--- a/Source/Arr.php
+++ b/Source/Arr.php
@@ -130,6 +130,11 @@ function reduce(array $array, Closure $callback, mixed $carry = null): mixed
     );
 }
 
+function skip(array $array, int $offset): array
+{
+    return array_slice($array, $offset);
+}
+
 function take(array &$array, Closure $condition): mixed
 {
     if (is_null($key = first_key($array, $condition))) {

--- a/Source/Collection.php
+++ b/Source/Collection.php
@@ -17,6 +17,7 @@ use function PhpRepos\Datatype\Arr\last;
 use function PhpRepos\Datatype\Arr\last_key;
 use function PhpRepos\Datatype\Arr\map;
 use function PhpRepos\Datatype\Arr\reduce;
+use function PhpRepos\Datatype\Arr\skip;
 use function PhpRepos\Datatype\Arr\take;
 
 class Collection implements ArrayAccess, IteratorAggregate, Countable
@@ -168,6 +169,14 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable
     public function reduce(Closure $closure, mixed $carry = null): mixed
     {
         return reduce($this->items, $closure, $carry);
+    }
+
+    public function skip(int $offset): static
+    {
+        $collection = new static();
+        $collection->items = skip($this->items(), $offset);
+
+        return $collection;
     }
 
     public function take(Closure $condition): mixed

--- a/Tests/Arr/SkipTest.php
+++ b/Tests/Arr/SkipTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Arr\SkipTest;
+
+use function PhpRepos\Datatype\Arr\skip;
+use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Runner\test;
+
+test(
+    title: 'it should skip up to given offset',
+    case: function () {
+        $arr = ['foo', 'bar', 'baz'];
+
+        assert_true(['foo', 'bar', 'baz'] === skip($arr, 0));
+        assert_true(['bar', 'baz'] === skip($arr, 1));
+        assert_true(['baz'] === skip($arr, 2));
+        assert_true([] === skip($arr, 3));
+    }
+);

--- a/Tests/Collection/SkipTest.php
+++ b/Tests/Collection/SkipTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Collection\TakeTest;
+
+use PhpRepos\Datatype\Collection;
+use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Runner\test;
+
+test(
+    title: 'it should return a collection with skipped items',
+    case: function () {
+        $collection = new Collection(['foo', 'bar', 'baz']);
+
+        assert_true(['foo', 'bar', 'baz'] === $collection->skip(0)->items(), 'Skip with offset 0 is not working!');
+        assert_true(['bar', 'baz'] === $collection->skip(1)->items(), 'Skip with offset 1 is not working!');
+        assert_true(['baz'] === $collection->skip(2)->items(), 'Skip with offset 2 is not working!');
+        assert_true([] === $collection->skip(3)->items(), 'Skip with offset 3 is not working!');
+    }
+);

--- a/Tests/Map/FilterTest.php
+++ b/Tests/Map/FilterTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Map\FilterTest;
+
+use PhpRepos\Datatype\Map;
+use PhpRepos\Datatype\Pair;
+use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Runner\test;
+
+test(
+    title: 'it should filter items by given closure',
+    case: function () {
+        $map = new Map();
+        $map->put(new Pair(1, 'foo'));
+        $map->put($item2 = new Pair(2, 'bar'));
+        $map->put($item3 = new Pair(3, 'baz'));
+        $map->put($item4 = new Pair(4, 'qux'));
+
+        $result = $map->filter(function (Pair $pair, $key) {
+            return $key === 1 || $pair->value === 'baz' || $pair->key === 4;
+        });
+
+        assert_true($result instanceof Map);
+        assert_true([1 => $item2, 2 => $item3, 3 => $item4] === $result->items());
+    }
+);
+
+test(
+    title: 'it should filter empty values when closure not passed',
+    case: function () {
+        $map = new Map();
+        $map->put(new Pair(1, null));
+        $map->put(new Pair(2, ''));
+        $map->put(new Pair(3, 0));
+        $map->put($item4 = new Pair(4, 'foo'));
+
+        $result = $map->filter();
+
+        assert_true($result instanceof Map);
+        assert_true([3 => $item4] === $result->items());
+    }
+);

--- a/Tests/Map/SkipTest.php
+++ b/Tests/Map/SkipTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Map\SkipTest;
+
+use PhpRepos\Datatype\Map;
+use PhpRepos\Datatype\Pair;
+use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Runner\test;
+
+test(
+    title: 'it should return a map with skipped items',
+    case: function () {
+        $map = new Map();
+        $map->push($item1 = new Pair(1, 'foo'));
+        $map->push($item2 = new Pair(2, 'bar'));
+        $map->push($item3 = new Pair(3, 'baz'));
+
+        assert_true([0 => $item1, 1 => $item2, 2 => $item3] === $map->skip(0)->items(), 'Offset 0 is not working!');
+        assert_true([0 => $item2, 1 => $item3] === $map->skip(1)->items(), 'Offset 1 is not working!');
+        assert_true([0 => $item3] === $map->skip(2)->items(), 'Offset 2 is not working!');
+        assert_true([] === $map->skip(3)->items(), 'Offset 3 is not working!');
+    }
+);


### PR DESCRIPTION
- `skip` function in `Arr`:
```
$arr = ['foo', 'bar', 'baz'];
assert_true(['foo', 'bar', 'baz'] === skip($arr, 0));
assert_true(['bar', 'baz'] === skip($arr, 1));
assert_true(['baz'] === skip($arr, 2));
assert_true([] === skip($arr, 3));
```

- `skip` on `Map`:
```
$map = new Map();
$map->push($item1 = new Pair(1, 'foo'));
$map->push($item2 = new Pair(2, 'bar'));
$map->push($item3 = new Pair(3, 'baz'));
assert_true([0 => $item1, 1 => $item2, 2 => $item3] === $map->skip(0)->items());
assert_true([0 => $item2, 1 => $item3] === $map->skip(1)->items());
assert_true([0 => $item3] === $map->skip(2)->items());
assert_true([] === $map->skip(3)->items());
```

- `skip` on `Collection`:
```
$collection = new Collection(['foo', 'bar', 'baz']);
assert_true(['foo', 'bar', 'baz'] === $collection->skip(0)->items());
assert_true(['bar', 'baz'] === $collection->skip(1)->items());
assert_true(['baz'] === $collection->skip(2)->items());
assert_true([] === $collection->skip(3)->items());
```