### PR TITLE
Remove test-runner from dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,4 +45,4 @@ jobs:
       - name: Execute tests
         run: |
           cd builds/production
-          php test-runner
+          ~/.phpkg/phpkg run https://github.com/php-repos/test-runner.git

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
-        php: [8.2, 8.1]
+        php: [8.3, 8.2, 8.1]
 
     name: P${{ matrix.php }} - ${{ matrix.os }}
 

--- a/Tests/Arr/EveryTest.php
+++ b/Tests/Arr/EveryTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Arr\EveryTest;
 
 use function PhpRepos\Datatype\Arr\every;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_false;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_false;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Arr/FirstKeyTest.php
+++ b/Tests/Arr/FirstKeyTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Arr\FirstKeyTest;
 
 use function PhpRepos\Datatype\Arr\first_key;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Arr/FirstTest.php
+++ b/Tests/Arr/FirstTest.php
@@ -4,7 +4,7 @@ namespace Tests\Arr\FirstTest;
 
 use function PhpRepos\Datatype\Arr\first;
 use function PhpRepos\Datatype\Str\first_character;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Arr/ForgetTest.php
+++ b/Tests/Arr/ForgetTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Arr\ForgetTest;
 
 use function PhpRepos\Datatype\Arr\forget;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Arr/HasTest.php
+++ b/Tests/Arr/HasTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Arr\HasTest;
 
 use function PhpRepos\Datatype\Arr\has;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_false;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_false;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Arr/InsertAfterTest.php
+++ b/Tests/Arr/InsertAfterTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Arr\InsertAfterTest;
 
 use function PhpRepos\Datatype\Arr\insert_after;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Arr/LastKeyTest.php
+++ b/Tests/Arr/LastKeyTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Arr\LastKeyTest;
 
 use function PhpRepos\Datatype\Arr\last_key;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Arr/LastTest.php
+++ b/Tests/Arr/LastTest.php
@@ -4,7 +4,7 @@ namespace Tests\Arr\LastTest;
 
 use function PhpRepos\Datatype\Arr\last;
 use function PhpRepos\Datatype\Str\first_character;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Arr/MapTest.php
+++ b/Tests/Arr/MapTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Arr\MapTest;
 
 use function PhpRepos\Datatype\Arr\map;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Arr/MaxKeyLengthTest.php
+++ b/Tests/Arr/MaxKeyLengthTest.php
@@ -6,7 +6,7 @@ use PhpRepos\Datatype\Collection;
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
 use function PhpRepos\Datatype\Arr\max_key_length;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Arr/ReduceTest.php
+++ b/Tests/Arr/ReduceTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Arr\ReduceTest;
 
 use function PhpRepos\Datatype\Arr\reduce;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Arr/SkipTest.php
+++ b/Tests/Arr/SkipTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Arr\SkipTest;
 
 use function PhpRepos\Datatype\Arr\skip;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Arr/TakeTest.php
+++ b/Tests/Arr/TakeTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Arr\TakeTest;
 
 use function PhpRepos\Datatype\Arr\take;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/CollectionTest.php
+++ b/Tests/Collection/CollectionTest.php
@@ -5,7 +5,7 @@ namespace Tests\Collection\CollectionTest;
 use ArrayAccess;
 use Countable;
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/EachTest.php
+++ b/Tests/Collection/EachTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\EachTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/EveryTest.php
+++ b/Tests/Collection/EveryTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Arr\EveryTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_false;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_false;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/ExceptTest.php
+++ b/Tests/Collection/ExceptTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\EachTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/FilterTest.php
+++ b/Tests/Collection/FilterTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\FilterTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/FirstKeyTest.php
+++ b/Tests/Collection/FirstKeyTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\FirstKeyTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/FirstTest.php
+++ b/Tests/Collection/FirstTest.php
@@ -4,7 +4,7 @@ namespace Tests\Collection\FirstTest;
 
 use PhpRepos\Datatype\Collection;
 use function PhpRepos\Datatype\Str\first_character;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/ForgetTest.php
+++ b/Tests/Collection/ForgetTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\ForgetTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/GetIteratorTest.php
+++ b/Tests/Collection/GetIteratorTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\GetIteratorTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/HasTest.php
+++ b/Tests/Collection/HasTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Collection\HasTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_false;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_false;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/ItemsTest.php
+++ b/Tests/Collection/ItemsTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\ItemsTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/KeysTest.php
+++ b/Tests/Collection/KeysTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\KeysTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/LastKeyTest.php
+++ b/Tests/Collection/LastKeyTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\LastKeyTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/LastTest.php
+++ b/Tests/Collection/LastTest.php
@@ -4,7 +4,7 @@ namespace Tests\Collection\LastTest;
 
 use PhpRepos\Datatype\Collection;
 use function PhpRepos\Datatype\Str\first_character;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/MapTest.php
+++ b/Tests/Collection/MapTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\MapTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/OffsetExistsTest.php
+++ b/Tests/Collection/OffsetExistsTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Collection\OffsetExistsTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_false;
+use function PhpRepos\TestRunner\Assertions\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_false;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/OffsetGetTest.php
+++ b/Tests/Collection/OffsetGetTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\OffsetGetTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/OffsetSetTest.php
+++ b/Tests/Collection/OffsetSetTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\OffsetSetTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/OffsetUnsetTest.php
+++ b/Tests/Collection/OffsetUnsetTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\OffsetUnsetTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/PushTest.php
+++ b/Tests/Collection/PushTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\PushTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/PutTest.php
+++ b/Tests/Collection/PutTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\PutTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/ReduceTest.php
+++ b/Tests/Collection/ReduceTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\ReduceTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/SkipTest.php
+++ b/Tests/Collection/SkipTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\TakeTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/TakeTest.php
+++ b/Tests/Collection/TakeTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\TakeTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Collection/ValuesTest.php
+++ b/Tests/Collection/ValuesTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Collection\ValuesTest;
 
 use PhpRepos\Datatype\Collection;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/EachTest.php
+++ b/Tests/Map/EachTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\EachTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/EveryTest.php
+++ b/Tests/Map/EveryTest.php
@@ -4,8 +4,8 @@ namespace Tests\Map\EveryTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_false;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_false;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/ExceptTest.php
+++ b/Tests/Map/ExceptTest.php
@@ -4,7 +4,7 @@ namespace Tests\Collection\ExceptTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/FilterTest.php
+++ b/Tests/Map/FilterTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\FilterTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/FirstKeyTest.php
+++ b/Tests/Map/FirstKeyTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\FirstKeyTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/FirstTest.php
+++ b/Tests/Map/FirstTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\FirstTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/ForgetTest.php
+++ b/Tests/Map/ForgetTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\ForgetTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/GetIteratorTest.php
+++ b/Tests/Map/GetIteratorTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\GetIteratorTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/HasTest.php
+++ b/Tests/Map/HasTest.php
@@ -4,8 +4,8 @@ namespace Tests\Map\HasTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_false;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_false;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/KeysTest.php
+++ b/Tests/Map/KeysTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\KeysTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/LastTest.php
+++ b/Tests/Map/LastTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\LastTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/MapClassTest.php
+++ b/Tests/Map/MapClassTest.php
@@ -5,7 +5,7 @@ namespace Tests\Map\MapClassTest;
 use Countable;
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/MapTest.php
+++ b/Tests/Map/MapTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\MapTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/OffsetExistsTest.php
+++ b/Tests/Map/OffsetExistsTest.php
@@ -4,8 +4,8 @@ namespace Tests\Map\OffsetExistsTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_false;
+use function PhpRepos\TestRunner\Assertions\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_false;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/OffsetGetTest.php
+++ b/Tests/Map/OffsetGetTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\OffsetGetTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/OffsetSetTest.php
+++ b/Tests/Map/OffsetSetTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\OffsetSetTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/OffsetUnsetTest.php
+++ b/Tests/Map/OffsetUnsetTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\OffsetUnsetTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/PushTest.php
+++ b/Tests/Map/PushTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\PushTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/PutTest.php
+++ b/Tests/Map/PutTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\PutTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/ReduceTest.php
+++ b/Tests/Map/ReduceTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\ReduceTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/SkipTest.php
+++ b/Tests/Map/SkipTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\SkipTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/TakeTest.php
+++ b/Tests/Map/TakeTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\TakeTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Map/ValuesTest.php
+++ b/Tests/Map/ValuesTest.php
@@ -4,7 +4,7 @@ namespace Tests\Map\ValuesTest;
 
 use PhpRepos\Datatype\Map;
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Pair/PairTest.php
+++ b/Tests/Pair/PairTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Pair\PairTest;
 
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Pair/ValueTest.php
+++ b/Tests/Pair/ValueTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Pair\ValueTest;
 
 use PhpRepos\Datatype\Pair;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/AfterFirstOccurrenceTest.php
+++ b/Tests/Str/AfterFirstOccurrenceTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\AfterFirstOccurrenceTest;
 
 use PhpRepos\Datatype\Str;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/AfterLastOccurrenceTest.php
+++ b/Tests/Str/AfterLastOccurrenceTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\AfterLastOccurrenceTest;
 
 use PhpRepos\Datatype\Str;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/BeforeFirstOccurrenceTest.php
+++ b/Tests/Str/BeforeFirstOccurrenceTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\BeforeFirstOccurrenceTest;
 
 use PhpRepos\Datatype\Str;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/BeforeLastOccurrenceTest.php
+++ b/Tests/Str/BeforeLastOccurrenceTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\BeforeLastOccurrenceTest;
 
 use PhpRepos\Datatype\Str;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/BetweenTest.php
+++ b/Tests/Str/BetweenTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\BetweenTest;
 
 use function PhpRepos\Datatype\Str\between;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/CamelCaseTest.php
+++ b/Tests/Str/CamelCaseTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\CamelCaseTest;
 
 use function PhpRepos\Datatype\Str\camel_case;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/ConcatTest.php
+++ b/Tests/Str/ConcatTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\ConcatTest;
 
 use function PhpRepos\Datatype\Str\concat;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/FirstCharacterTest.php
+++ b/Tests/Str/FirstCharacterTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\FirstCharacterTest;
 
 use PhpRepos\Datatype\Str;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/FirstLineTest.php
+++ b/Tests/Str/FirstLineTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\FirstLineTest;
 
 use function PhpRepos\Datatype\Str\first_line;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/KebabCaseTest.php
+++ b/Tests/Str/KebabCaseTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\KebabCaseTest;
 
 use function PhpRepos\Datatype\Str\kebab_case;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/LastCharacterTest.php
+++ b/Tests/Str/LastCharacterTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\LastCharacterTest;
 
 use PhpRepos\Datatype\Str;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/PascalCaseTest.php
+++ b/Tests/Str/PascalCaseTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\PascalCaseTest;
 
 use function PhpRepos\Datatype\Str\pascal_case;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/PrependWhenExists.php
+++ b/Tests/Str/PrependWhenExists.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\PrependWhenExistsTest;
 
 use function PhpRepos\Datatype\Str\prepend_when_exists;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/RemoveFirstCharacterTest.php
+++ b/Tests/Str/RemoveFirstCharacterTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\RemoveFirstCharacterTest;
 
 use PhpRepos\Datatype\Str;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/RemoveLastCharacterTest.php
+++ b/Tests/Str/RemoveLastCharacterTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\RemoveLastCharacterTest;
 
 use PhpRepos\Datatype\Str;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/ReplaceFirstOccurrenceTest.php
+++ b/Tests/Str/ReplaceFirstOccurrenceTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\ReplaceFirstOccurrenceTest;
 
 use PhpRepos\Datatype\Str;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/SnakeCaseTest.php
+++ b/Tests/Str/SnakeCaseTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\SnakeCaseTest;
 
 use function PhpRepos\Datatype\Str\snake_case;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/StartsWithRegexTest.php
+++ b/Tests/Str/StartsWithRegexTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Str\StartsWithRegexTest;
 
 use function PhpRepos\Datatype\Str\starts_with_regex;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_false;
+use function PhpRepos\TestRunner\Assertions\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_false;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Str/WordsTest.php
+++ b/Tests/Str/WordsTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Str\WordsTest;
 
 use function PhpRepos\Datatype\Str\words;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Text/SetTest.php
+++ b/Tests/Text/SetTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Text\SetTest;
 
 use PhpRepos\Datatype\Text;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Text/TextTest.php
+++ b/Tests/Text/TextTest.php
@@ -4,7 +4,7 @@ namespace Tests\Text\TextTest;
 
 use PhpRepos\Datatype\Text;
 use Stringable;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Tree/EdgeTest.php
+++ b/Tests/Tree/EdgeTest.php
@@ -4,7 +4,7 @@ namespace Tests\Tree\EdgeTest;
 
 use PhpRepos\Datatype\Pair;
 use PhpRepos\Datatype\Tree;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/Tree/TreeTest.php
+++ b/Tests/Tree/TreeTest.php
@@ -4,7 +4,7 @@ namespace Tests\Tree\TreeTest;
 
 use PhpRepos\Datatype\Collection;
 use PhpRepos\Datatype\Tree;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/phpkg.config-lock.json
+++ b/phpkg.config-lock.json
@@ -1,28 +1,3 @@
 {
-    "packages": {
-        "git@github.com:php-repos\/test-runner.git": {
-            "owner": "php-repos",
-            "repo": "test-runner",
-            "version": "v1.1.0",
-            "hash": "119c47953485a6ec127cd896a70e96376306a954"
-        },
-        "https:\/\/github.com\/php-repos\/cli.git": {
-            "owner": "php-repos",
-            "repo": "cli",
-            "version": "v1.0.0",
-            "hash": "9d8bd24f9d31b5bf18bc01e89053d311495f714d"
-        },
-        "https:\/\/github.com\/php-repos\/file-manager.git": {
-            "owner": "php-repos",
-            "repo": "file-manager",
-            "version": "v2.0.0",
-            "hash": "e5104a58dd4192c95701d414373b3add3e504bff"
-        },
-        "git@github.com:php-repos\/datatype.git": {
-            "owner": "php-repos",
-            "repo": "datatype",
-            "version": "v1.0.0",
-            "hash": "e802ba8c0cb2ffe2282de401bbf9e84a4ce1316a"
-        }
-    }
+    "packages": []
 }

--- a/phpkg.config.json
+++ b/phpkg.config.json
@@ -3,14 +3,12 @@
         "PhpRepos\\Datatype": "Source",
         "Tests": "Tests"
     },
-    "entry-points": [],
+    "autoloads": [],
     "excludes": [],
+    "entry-points": [],
     "executables": [],
+    "import-file": "phpkg.imports.php",
     "packages-directory": "Packages",
-    "packages": {
-        "git@github.com:php-repos\/test-runner.git": "v1.1.0"
-    },
-    "aliases": {
-        "test-runner": "git@github.com:php-repos\/test-runner.git"
-    }
+    "packages": [],
+    "aliases": []
 }


### PR DESCRIPTION
`test-runner` can be used as a tool. This PR removes it from dependencies.