### PR TITLE
Add implicit nullable to functions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
-        php: [8.3, 8.2, 8.1]
+        php: [8.2, 8.3, 8.4]
 
     name: P${{ matrix.php }} - ${{ matrix.os }}
 

--- a/Source/Arr.php
+++ b/Source/Arr.php
@@ -6,7 +6,7 @@ use Closure;
 use PhpRepos\Datatype\Collection;
 use PhpRepos\Datatype\Map;
 
-function every(array $array, Closure $check = null): bool
+function every(array $array, ?Closure $check = null): bool
 {
     if (is_callable($check)) {
         foreach ($array as $key => $value) {
@@ -21,7 +21,7 @@ function every(array $array, Closure $check = null): bool
     return ! empty(array_filter($array));
 }
 
-function first_key(array $array, Closure $condition = null): string|int|null
+function first_key(array $array, ?Closure $condition = null): string|int|null
 {
     if (is_callable($condition)) {
         foreach ($array as $key => $value) {
@@ -36,7 +36,7 @@ function first_key(array $array, Closure $condition = null): string|int|null
     return array_key_first($array) ?? null;
 }
 
-function first(array $array, Closure $condition = null): mixed
+function first(array $array, ?Closure $condition = null): mixed
 {
     if (is_callable($condition)) {
         foreach ($array as $key => $value) {
@@ -82,7 +82,7 @@ function insert_after(array $array, mixed $key, array $additional): array
     return array_merge(array_slice($array, 0, $pos), $additional, array_slice($array, $pos));
 }
 
-function last_key(array $array, Closure $condition = null): null|int|string
+function last_key(array $array, ?Closure $condition = null): null|int|string
 {
     if (is_callable($condition)) {
         $last = null;
@@ -96,7 +96,7 @@ function last_key(array $array, Closure $condition = null): null|int|string
     return array_key_last($array) ?? null;
 }
 
-function last(array $array, Closure $condition = null): mixed
+function last(array $array, ?Closure $condition = null): mixed
 {
     if (is_callable($condition)) {
         $last = null;

--- a/Source/Collection.php
+++ b/Source/Collection.php
@@ -43,12 +43,12 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable
         return $this;
     }
 
-    public function every(Closure $check = null): bool
+    public function every(?Closure $check = null): bool
     {
         return every($this->items(), $check);
     }
 
-    public function except(Closure $check = null): static
+    public function except(?Closure $check = null): static
     {
         $check = $check ?? function ($value) {
             return (bool) $value;
@@ -65,7 +65,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable
         return new static($results);
     }
 
-    public function filter(Closure $closure = null): static
+    public function filter(?Closure $closure = null): static
     {
         if ($closure) {
             $results = [];
@@ -82,12 +82,12 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable
         return new static(array_filter($this->items));
     }
 
-    public function first_key(Closure $condition = null): string|int|null
+    public function first_key(?Closure $condition = null): string|int|null
     {
         return first_key($this->items(), $condition);
     }
 
-    public function first(Closure $condition = null): mixed
+    public function first(?Closure $condition = null): mixed
     {
         return first($this->items(), $condition);
     }
@@ -119,12 +119,12 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable
         return array_keys($this->items);
     }
 
-    public function last_key(Closure $condition = null): string|int|null
+    public function last_key(?Closure $condition = null): string|int|null
     {
         return last_key($this->items(), $condition);
     }
 
-    public function last(Closure $condition = null): mixed
+    public function last(?Closure $condition = null): mixed
     {
         return last($this->items(), $condition);
     }

--- a/Source/Map.php
+++ b/Source/Map.php
@@ -45,14 +45,14 @@ class Map implements ArrayAccess, IteratorAggregate, Countable
         return $this;
     }
 
-    public function every(Closure $check = null): bool
+    public function every(?Closure $check = null): bool
     {
         $check = $check ? fn (Pair $pair) => $check($pair) : fn (Pair $pair) => $pair->value;
 
         return every($this->items, $check);
     }
 
-    public function except(Closure $check = null): static
+    public function except(?Closure $check = null): static
     {
         $check = $check ?? function (Pair $pair) {
             return (bool) $pair->value;
@@ -63,7 +63,7 @@ class Map implements ArrayAccess, IteratorAggregate, Countable
         }, new static([]));
     }
 
-    public function filter(Closure $check = null): static
+    public function filter(?Closure $check = null): static
     {
         $check = $check ?? function (Pair $pair) {
             return (bool) $pair->value;
@@ -74,14 +74,14 @@ class Map implements ArrayAccess, IteratorAggregate, Countable
         }, new static([]));
     }
 
-    public function first_key(Closure $closure = null): null|int|string
+    public function first_key(?Closure $closure = null): null|int|string
     {
         $key = first_key($this->items, $closure);
 
         return $this->items[$key]?->key;
     }
 
-    public function first(Closure $condition = null): ?Pair
+    public function first(?Closure $condition = null): ?Pair
     {
         return first($this->items, $condition);
     }
@@ -108,7 +108,7 @@ class Map implements ArrayAccess, IteratorAggregate, Countable
         return $this->items;
     }
 
-    public function last(Closure $condition = null): ?Pair
+    public function last(?Closure $condition = null): ?Pair
     {
         return last($this->items, $condition);
     }


### PR DESCRIPTION
This PR adds implicit nullable to eliminate deprecation errors on PHP 8.4
